### PR TITLE
Line 215: WAYLAND"NO" is not a command fixed

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -212,7 +212,7 @@ esac
 if [[ $XDG_SESSION_TYPE == "wayland" ]]; then
 	WAYLAND="NO" #Currently defaulting to NO as osu!lazer still has issues with wayland enabled
 else
-	WAYLAND"NO"
+	WAYLAND="NO"
 fi
 
 


### PR DESCRIPTION
when I tried to run the .sh file, there was a misspelled command: from WAYLAND"NO" (not changing the variable) to WAYLAND = "NO" (now working correctly)
thank you for this installer :)